### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lua]
+max_line_length = 160
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` at the repo root to align editor defaults across editors and contributors.

## Motivation
Editors that read `.editorconfig` (Neovim 0.9+ does so natively, plus VS Code, JetBrains, Sublime, etc.) will now pick up consistent whitespace settings without manual configuration. Lua-specific settings match `.stylua.toml` so that on-keystroke formatting does not fight the canonical formatter.

## Changes
- Universal defaults: UTF-8, LF line endings, 2-space indent, trim trailing whitespace, insert final newline.
- `*.lua`: `max_line_length = 160` to match `column_width` in `.stylua.toml`.
- `*.md`: `trim_trailing_whitespace = false` to preserve Markdown's two-trailing-space hard-line-break syntax.
- `Makefile`: `indent_style = tab` (required by `make`; harmless if no Makefile is ever added).

## Test Plan
- [ ] Open a Lua file in Neovim and confirm indent/width matches `.stylua.toml`.
- [ ] Open `README.md` and verify trailing-space preservation is honored (no auto-trim).
- [ ] Run `stylua --check .` and confirm it still passes.