### PR TITLE
fix(ci): remove kickstart fork guard from stylua workflow

### DIFF
--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -4,7 +4,6 @@ on: pull_request_target
 
 jobs:
   stylua-check:
-    if: github.repository == 'nvim-lua/kickstart.nvim'
     name: Stylua Check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Removes the `if: github.repository == 'nvim-lua/kickstart.nvim'` guard from `.github/workflows/stylua.yml` so the lint job actually runs on this fork.

## Motivation
The guard is a holdover from the kickstart-modular fork chain. On `ocrosby/nvim` it evaluates `false` on every PR, so the workflow has been silently skipping every run since the repository was created. The README badge stays green only because no job ever executes to produce a failure. This is exactly what let the snacks formatting drift (fixed in `772e647`) slip past CI when it should have blocked the PR.

## Changes
- `.github/workflows/stylua.yml`: deleted the one-line `if:` guard. The `name`, `runs-on`, and steps are unchanged.

## Test Plan
- [ ] After merge, observe the `Check Lua Formatting` job actually run on the next PR (PR 6 or 7 if either is still open).
- [ ] Confirm the README badge reflects real CI status, not the "no runs" green default.