### PR TITLE
chore(github): minimal rewrite of bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,35 +1,26 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug in nvim-personal
 title: ''
-labels: ''
+labels: bug
 assignees: ''
-
 ---
 
-<!-- Any bug report not following this template will be immediately closed. Thanks -->
-
-## Before Reporting an Issue
-- I have read the kickstart.nvim README.md.
-- I have read the appropriate plugin's documentation.
-- I have searched that this issue has not been reported before.
-
-- [ ] **By checking this, I confirm that the above steps are completed. I understand leaving this unchecked will result in this report being closed immediately.**
-
 ## Describe the bug
-<!-- A clear and concise description of what the bug is. -->
 
-## To Reproduce
-<!-- Steps to reproduce the behavior. -->
-1. ...
 
-## Desktop
-<!-- please complete the following information. -->
+## To reproduce
+
+1.
+
+## Neovim version
+
+<!-- Output of `:version` -->
+
+```
+```
+
+## Environment
+
 - OS:
 - Terminal:
-
-## Neovim Version
-<!-- Output of running `:version` from inside of neovim. -->
-
-```
-```


### PR DESCRIPTION
## Summary
- Replaces the kickstart-inherited bug report template with a minimal personal-repo version.

## Motivation
The previous template required the reporter to confirm they had read the kickstart.nvim README and gated submission on a "I confirm..." checkbox under threat of immediate closure. This made sense for a high-volume upstream project; it does not for a single-user personal repository.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.md`: kept describe / repro steps / nvim version / environment. Dropped the kickstart README requirement, the doc-reading checklist, and the gatekeeping checkbox. Default label set to `bug`.

## Test Plan
- [ ] Open a new issue draft on GitHub and confirm the new template loads correctly.
- [ ] Verify the `bug` label is auto-applied to new issues using this template.